### PR TITLE
Fix for "std::gets" error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,9 @@
 # cecs460
 
-1- Make sure you add this line to your ~/.bashrc file
+### Important Info:
+
+Make sure you add this line to your ~/.bashrc file
 
 export SYSTEMC_HOME=/PATH/TO/YOUR/SYSTEMC
-
-2- If you get an error regarding std::gets, do the following:
-
-sudo vim $SYSTEMC_HOME/include/systemc.h
-
-#** replace this line 
-
-using std::gets;
-
-#** with this:
-
-#if defined(__cplusplus) && (__cplusplus < 201103L)
-using std::gets;
-#endif
 
 

--- a/labs/lab-1/build_hello.sh
+++ b/labs/lab-1/build_hello.sh
@@ -1,6 +1,6 @@
 echo "### Building ..."
 echo
-g++ -I. -I$SYSTEMC_HOME/include -L. -L$SYSTEMC_HOME/lib-linux64 -Wl,-rpath=$SYSTEMC_HOME/lib-linux64 -o hello hello.cpp -lsystemc -lm
+g++ -std=c++98 -I. -I$SYSTEMC_HOME/include -L. -L$SYSTEMC_HOME/lib-linux64 -Wl,-rpath=$SYSTEMC_HOME/lib-linux64 -o hello hello.cpp -lsystemc -lm
 
 ###
 

--- a/labs/lab-2/build.sh
+++ b/labs/lab-2/build.sh
@@ -1,6 +1,6 @@
 echo "### Building ..."
 echo
-g++ -I. -I$SYSTEMC_HOME/include -L. -L$SYSTEMC_HOME/lib-linux64 -Wl,-rpath=$SYSTEMC_HOME/lib-linux64 -o runme top.cpp -lsystemc -lm
+g++ -std=c++98 -I. -I$SYSTEMC_HOME/include -L. -L$SYSTEMC_HOME/lib-linux64 -Wl,-rpath=$SYSTEMC_HOME/lib-linux64 -o runme top.cpp -lsystemc -lm
 ###
 
 echo "Build is finished and you can try running it using: "

--- a/labs/lab-3/part-1/build.sh
+++ b/labs/lab-3/part-1/build.sh
@@ -1,6 +1,6 @@
 echo "### Building ..."
 echo
-g++ -I. -I$SYSTEMC_HOME/include -L. -L$SYSTEMC_HOME/lib-linux64 -Wl,-rpath=$SYSTEMC_HOME/lib-linux64 -o runme simple_fifo.cpp -lsystemc -lm
+g++ -std=c++98 -I. -I$SYSTEMC_HOME/include -L. -L$SYSTEMC_HOME/lib-linux64 -Wl,-rpath=$SYSTEMC_HOME/lib-linux64 -o runme simple_fifo.cpp -lsystemc -lm
 ###
 
 echo "Build is finished and you can try running it using: "

--- a/labs/lab-3/part-2/build.sh
+++ b/labs/lab-3/part-2/build.sh
@@ -1,6 +1,6 @@
 echo "### Building ..."
 echo
-g++ -I. -I$SYSTEMC_HOME/include -L. -L$SYSTEMC_HOME/lib-linux64 -Wl,-rpath=$SYSTEMC_HOME/lib-linux64 -o runme fifo_perf.cpp -lsystemc -lm
+g++ -std=c++98 -I. -I$SYSTEMC_HOME/include -L. -L$SYSTEMC_HOME/lib-linux64 -Wl,-rpath=$SYSTEMC_HOME/lib-linux64 -o runme fifo_perf.cpp -lsystemc -lm
 ###
 
 echo "Build is finished and you can try running it using: "


### PR DESCRIPTION
This forces gcc to use the C++98 standard, which means that user's won't have to edit their systemc install in order to compile the different projects.